### PR TITLE
Order holds had to be changed 

### DIFF
--- a/lib/spire/order.rb
+++ b/lib/spire/order.rb
@@ -73,7 +73,7 @@ module Spire
     ACTIVE = false
     ON_HOLD = true
 
-    #Statuses
+    #Statuses - These are to track the flow of the order throughout its lifespan
     OPEN = "O"
     PROCESSED = "P"
     DEPOSITED = "L"
@@ -224,6 +224,7 @@ module Spire
         freight: freight || "",
         customerPO: customer_po || "",
         type: type || "O",
+        hold: hold || ACTIVE,
         backgroundColor: background_color || 16777215
       }
 
@@ -256,25 +257,18 @@ module Spire
       client.delete("/sales/orders/#{id}")
     end
 
-    # Sets status to inactive.
-    # This will not make any changes on Spire.
-    # If you want to save changes to Spire call .save or .update!
-    def make_inactive
-      self.status = INACTIVE
-    end
-
     # Sets status to on hold.
     # This will not make any changes on Spire.
     # If you want to save changes to Spire call .save or .update!
     def put_on_hold
-      self.status = ON_HOLD
+      self.hold = ON_HOLD
     end
 
     # Sets status to active.
     # This will not make any changes on Spire.
     # If you want to save changes to Spire call .save or .update!
     def make_active
-      self.status = ACTIVE
+      self.hold = ACTIVE
     end
 
     # Is the record valid?

--- a/lib/spire/order.rb
+++ b/lib/spire/order.rb
@@ -69,9 +69,15 @@ module Spire
 
     validates_presence_of :id, :customer, :address, :shipping_address, :items
 
-    ACTIVE = "0"
-    ON_HOLD = "1"
-    INACTIVE = "2"
+    # Canceling an order on Web is the HOLD function in the spire client
+    ACTIVE = false
+    ON_HOLD = true
+
+    #Statuses
+    OPEN = "O"
+    PROCESSED = "P"
+    DEPOSITED = "L"
+
 
     SYMBOL_TO_STRING = {
       id: 'id',

--- a/lib/spire/version.rb
+++ b/lib/spire/version.rb
@@ -1,3 +1,3 @@
 module Spire
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
in order to mark orders as canceled from the web to spire, we need to access the hold property which will put a restriction on the order itself in the spire client 

once on hold it cannot be actioned until the hold is removed, there is a clear visible warning saying order is on hold and must be removed from hold in order for it to be worked on